### PR TITLE
Include quill-blot-formatter.min.js in CSPROJ

### DIFF
--- a/src/WYSIWYGTextEditor/WYSIWYGTextEditor.csproj
+++ b/src/WYSIWYGTextEditor/WYSIWYGTextEditor.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <None Include="wwwroot\BlazorQuill.js" />
+    <None Include="wwwroot\quill-blot-formatter.min.js" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Both JS files need to be included based on the documentation. Should both be include?