### PR TITLE
add support for 'class' and 'style' in Toolbar and Editor containers

### DIFF
--- a/samples/BlazorClientSide/BlazorClientSide.csproj
+++ b/samples/BlazorClientSide/BlazorClientSide.csproj
@@ -16,4 +16,11 @@
     <ProjectReference Include="..\..\src\WYSIWYGTextEditor\WYSIWYGTextEditor.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="Properties\launchSettings.json">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/samples/BlazorServerSide/BlazorServerSide.csproj
+++ b/samples/BlazorServerSide/BlazorServerSide.csproj
@@ -8,4 +8,11 @@
     <ProjectReference Include="..\..\src\WYSIWYGTextEditor\WYSIWYGTextEditor.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="Properties\launchSettings.json">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/WYSIWYGTextEditor/TextEditor.razor
+++ b/src/WYSIWYGTextEditor/TextEditor.razor
@@ -1,7 +1,7 @@
 ﻿@inject IJSRuntime JSRuntime
 @namespace WYSIWYGTextEditor
 @using WYSIWYGTextEditor.Internal
-<div @ref="@ToolBar">
+<div class="@ToolbarContainerClass" style="@ToolbarContainerStyle" @ref="@ToolBar">
     @if (Toolbar != null)
     {
         <CascadingValue Value="Toolbar">
@@ -14,7 +14,7 @@
 
     @ToolbarContent
 </div>
-<div id="@EditorContainerId" @ref="@QuillElement">
+<div class="@EditorContainerClass" style="@EditorContainerStyle" id="@EditorContainerId" @ref="@QuillElement">
     @EditorContent
 </div>
 
@@ -27,7 +27,26 @@
     public string EditorContainerId { get; set; }
     [Parameter]
     public RenderFragment EditorContent { get; set; }
-
+    /// <summary>
+    /// Supports normal css classes
+    /// </summary>
+    [Parameter]
+    public string EditorContainerClass { get; set; } = string.Empty;
+    /// <summary>
+    /// Supports normal css style
+    /// </summary>
+    [Parameter]
+    public string EditorContainerStyle { get; set; } = string.Empty;
+    /// <summary>
+    /// Supports normal css classes
+    /// </summary>
+    [Parameter]
+    public string ToolbarContainerClass { get; set; } = string.Empty;
+    /// <summary>
+    /// Supports normal css style
+    /// </summary>
+    [Parameter]
+    public string ToolbarContainerStyle { get; set; } = string.Empty;
     [Parameter]
     public RenderFragment ToolbarContent { get; set; }
 

--- a/src/WYSIWYGTextEditor/WYSIWYGTextEditor.csproj
+++ b/src/WYSIWYGTextEditor/WYSIWYGTextEditor.csproj
@@ -1,32 +1,28 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RazorLangVersion>3.0</RazorLangVersion>
-    <RootNamespace>WYSIWYGTextEditor</RootNamespace>
-
-    <PackageId>WYSIWYGTextEditor</PackageId>
-    <Version>1.0.0</Version>
-    <Authors>somegenericdev, Michael Washington</Authors>
-    <Description>WYSIWYG Rich text editor for Blazor applications, forked from Blazored.TextEditor - Uses Quill JS</Description>
-    <Copyright>Copyright 2019 (c) Michael Washington. All rights reserved.</Copyright>
-    <Copyright>Copyright 2021 (c) somegenericdev. All rights reserved.</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/somegenericdev/TextEditor</PackageProjectUrl>
-	<PackageIconUrl>https://raw.githubusercontent.com/somegenericdev/TextEditor/main/src/WYSIWYGTextEditor/wwwroot/QuillLogo.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/somegenericdev/TextEditor</RepositoryUrl>
-    <PackageTags>Blazor Rich Text Editor Quill QuillJS WYSIWYG Blazored Razor Components</PackageTags>
-    <Company />
-    <PackageReleaseNotes>Allows images to be resized</PackageReleaseNotes>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="wwwroot\BlazorQuill.js" />
-  </ItemGroup>
-
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RazorLangVersion>3.0</RazorLangVersion>
+		<RootNamespace>WYSIWYGTextEditor</RootNamespace>
+		<PackageId>WYSIWYGTextEditor</PackageId>
+		<Version>1.1.0</Version>
+		<Authors>somegenericdev, Michael Washington</Authors>
+		<Description>WYSIWYG Rich text editor for Blazor applications, forked from Blazored.TextEditor - Uses Quill JS</Description>
+		<Copyright>Copyright 2019 (c) Michael Washington. All rights reserved.</Copyright>
+		<Copyright>Copyright 2021 (c) somegenericdev. All rights reserved.</Copyright>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/somegenericdev/TextEditor</PackageProjectUrl>
+		<PackageIconUrl>https://raw.githubusercontent.com/somegenericdev/TextEditor/main/src/WYSIWYGTextEditor/wwwroot/QuillLogo.png</PackageIconUrl>
+		<RepositoryUrl>https://github.com/somegenericdev/TextEditor</RepositoryUrl>
+		<PackageTags>Blazor Rich Text Editor Quill QuillJS WYSIWYG Blazored Razor Components</PackageTags>
+		<Company />
+		<PackageReleaseNotes>Allows images to be resized</PackageReleaseNotes>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="wwwroot\BlazorQuill.js" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
The property names can be modified. The essential aspect is the flexibility to customize both the Toolbar and the Editor. This customization capability proves helpful in resolving an issue encountered while using the Editor on Android. Specifically, when text is selected within the Editor, the Android popup text selector conceals the Toolbar buttons, rendering them unusable. By adding padding to the top of the editor, this problem can be effectively resolved. Additionally, enabling styling on the Editor becomes an added advantage.